### PR TITLE
Changes to null primary key handling

### DIFF
--- a/cmd/parents.go
+++ b/cmd/parents.go
@@ -68,7 +68,7 @@ func Parents(cmd *cobra.Command, args []string) error {
 			t.Rows = append(t.Rows, newRow)
 		}
 	}
-	err = db.InsertEmails(t)
+	err = db.InsertParentEmails(t)
 	if err != nil {
 		slog.Error("Unable to insert emails", slog.Any("error", err))
 		return err


### PR DESCRIPTION
Removes calls to removeNull for primaryKeys as in most cases that mea…ns something has gone wrong. Also renames InsertEmails to InsertParentEmails as it contains a postgres query specific to the parents table.